### PR TITLE
add timeout option for database connections

### DIFF
--- a/postgresql_metrics/postgres_queries.py
+++ b/postgresql_metrics/postgres_queries.py
@@ -28,12 +28,14 @@ LOG = get_logger()
 DERIVE_DICT = dict()
 
 
-def get_db_connection(database, username, password, host='127.0.0.1', port=5432):
+def get_db_connection(database, username, password, host='127.0.0.1', port=5432,
+                      connect_timeout=10):
     connection = psycopg2.connect(user=username,
                                   password=password,
                                   host=host,
                                   port=int(port),
-                                  database=database)
+                                  database=database,
+                                  connect_timeout=connect_timeout)
     connection.autocommit = True
     return connection
 


### PR DESCRIPTION
It is better to throw exception after 10 seconds that stay hanging ad infinitum.
