### PR TITLE
Reporting replication status from WAL receiver processes

### DIFF
--- a/etc/postgresql-metrics/default/postgresql-metrics.yml
+++ b/etc/postgresql-metrics/default/postgresql-metrics.yml
@@ -49,6 +49,7 @@ db_functions:
     # table bloat is a heavy query, which might take many minutes to execute for huge tables
     # 43200 = 12*60*60 = 12 hours
     - ["get_stats_table_bloat", 43200]
+    - ["get_stats_incoming_replication_status", 30]
 
 # global_db_functions: Functions taking DB connection and returning a list of metrics,
 #                      called once per the whole database cluster.

--- a/etc/postgresql-metrics/default/postgresql-metrics.yml
+++ b/etc/postgresql-metrics/default/postgresql-metrics.yml
@@ -49,7 +49,8 @@ db_functions:
     # table bloat is a heavy query, which might take many minutes to execute for huge tables
     # 43200 = 12*60*60 = 12 hours
     - ["get_stats_table_bloat", 43200]
-    - ["get_stats_incoming_replication_status", 30]
+    # replication status relies on `pg_stat_wal_receiver`, which is only available on postgres 9.6+
+    # - ["get_stats_incoming_replication_status", 30]
 
 # global_db_functions: Functions taking DB connection and returning a list of metrics,
 #                      called once per the whole database cluster.

--- a/postgresql_metrics/default_metrics.py
+++ b/postgresql_metrics/default_metrics.py
@@ -143,3 +143,10 @@ def metric_replication_delay_bytes(client_addr, value):
                                  {'what': 'replication-delay-bytes',
                                   'slave': client_addr,
                                   'unit': 'B'})
+
+
+def metric_incoming_replication_running(replication_host, value):
+    return create_default_metric(value == "streaming",
+                                 {'what': 'incoming-replication-running',
+                                  'master': replication_host,
+                                  'unit': 'msg'})

--- a/postgresql_metrics/default_metrics.py
+++ b/postgresql_metrics/default_metrics.py
@@ -146,7 +146,7 @@ def metric_replication_delay_bytes(client_addr, value):
 
 
 def metric_incoming_replication_running(replication_host, value):
-    return create_default_metric(value == "streaming",
+    return create_default_metric(value,
                                  {'what': 'incoming-replication-running',
                                   'master': replication_host,
                                   'unit': 'msg'})

--- a/postgresql_metrics/metrics_gatherer.py
+++ b/postgresql_metrics/metrics_gatherer.py
@@ -154,5 +154,5 @@ def get_stats_wal_file_amount(data_dir):
 
 
 def get_stats_incoming_replication_status(db_connection):
-    return [metric_incoming_replication_running(host, status)
-            for host, status in get_wal_receiver_status(db_connection)]
+    return [metric_incoming_replication_running(host, is_streaming)
+            for host, is_streaming in get_wal_receiver_status(db_connection)]

--- a/postgresql_metrics/metrics_gatherer.py
+++ b/postgresql_metrics/metrics_gatherer.py
@@ -42,6 +42,7 @@ from postgresql_metrics.default_metrics import (
     metric_index_hit_ratio,
     metric_replication_delay_bytes,
     metric_wal_file_amount,
+    metric_incoming_replication_running,
 )
 
 from postgresql_metrics.localhost_postgres_stats import get_amount_of_wal_files
@@ -58,6 +59,7 @@ from postgresql_metrics.postgres_queries import (
     get_index_hit_rates,
     get_replication_delays,
     get_tables_with_oids_for_current_db,
+    get_wal_receiver_status,
 )
 
 
@@ -149,3 +151,8 @@ def get_stats_replication_delays(db_connection):
 
 def get_stats_wal_file_amount(data_dir):
     return [metric_wal_file_amount(get_amount_of_wal_files(data_dir))]
+
+
+def get_stats_incoming_replication_status(db_connection):
+    return [metric_incoming_replication_running(host, status)
+            for host, status in get_wal_receiver_status(db_connection)]

--- a/postgresql_metrics/postgres_queries.py
+++ b/postgresql_metrics/postgres_queries.py
@@ -242,7 +242,8 @@ def get_index_hit_rates(conn):
 
 
 def get_wal_receiver_status(conn):
-    sql = "SELECT conninfo, status FROM pg_stat_wal_receiver"
+    sql = ("SELECT conninfo, CASE WHEN status = 'streaming' THEN 1 ELSE 0 END "
+           "FROM pg_stat_wal_receiver")
     results = query(conn, sql)
     host_replication_status = []
     for conn_info, status in results:


### PR DESCRIPTION
This relies on `pg_stat_wal_receiver` to check status of the wal receivers, and reports a boolean value for whether streaming replication is running or not for each of the hosts returned.