### PR TITLE
Extracting incoming replication status from custom view

### DIFF
--- a/postgresql_metrics/postgres_queries.py
+++ b/postgresql_metrics/postgres_queries.py
@@ -243,7 +243,7 @@ def get_index_hit_rates(conn):
 
 def get_wal_receiver_status(conn):
     sql = ("SELECT conninfo, CASE WHEN status = 'streaming' THEN 1 ELSE 0 END "
-           "FROM pg_stat_wal_receiver")
+           "FROM public.stat_incoming_replication")
     results = query(conn, sql)
     host_replication_status = []
     for conn_info, status in results:


### PR DESCRIPTION
This uses a SECURITY DEFINER function to wrap `pg_stat_wal_receiver`,
which allows us to not require SUPERUSER for gathering the metric.