### PR TITLE
Make `sec-since-oldest-xact-start` metric database-specific

### DIFF
--- a/postgresql_metrics/postgres_queries.py
+++ b/postgresql_metrics/postgres_queries.py
@@ -184,7 +184,8 @@ def get_lock_statistics(conn):
 
 
 def get_oldest_transaction_timestamp(conn):
-    sql = ("SELECT datname, now(), xact_start FROM pg_stat_activity WHERE xact_start IS NOT NULL "
+    sql = ("SELECT datname, now(), xact_start FROM pg_stat_activity "
+           "WHERE xact_start IS NOT NULL AND datname=current_database() "
            "ORDER BY xact_start ASC LIMIT 1")
     results = query(conn, sql)
     if results:


### PR DESCRIPTION
This fixes a bug, where `sec-since-oldest-xact-start` is only reported for one largest transaction per monitored postgresql instance. This can lead to a situation, where spurious databases appear in metrics, and not more than 1 database is reported at every iteration.

We would like to add database comparison name with the currently connected database. Since postgresql connects to every monitored database separately, this will effectively output `sec-since-oldest-xact-start` metrics per connected database.